### PR TITLE
Use all commit properties available in git

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -237,10 +237,6 @@
                         <generateGitPropertiesFile>true</generateGitPropertiesFile>
                         <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
                         <injectAllReactorProjects>true</injectAllReactorProjects>
-                        <includeOnlyProperties>
-                            <include>git.commit.id</include>
-                            <include>git.commit.id.abbrev</include>
-                        </includeOnlyProperties>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
Previous config limits output in git.properties file and other places too. So it's global switch which disabled on only properties pushed to maven build but also down to generated meta file.